### PR TITLE
Fixes and improvements for release deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,25 +79,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.5</version>
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <serverId>nexus-releases</serverId>
-                            <nexusUrl>http://localhost:8081/nexus/</nexusUrl>
-                            <skipStaging>true</skipStaging>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.10.1</version>
@@ -105,11 +86,27 @@
                             <show>private</show>
                             <nohelp>true</nohelp>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>2.4</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -118,8 +115,9 @@
                         <configuration>
                             <tagNameFormat>v@{project.version}</tagNameFormat>
                             <autoVersionSubmodules>true</autoVersionSubmodules>
+                            <releaseProfiles>release</releaseProfiles>
                         </configuration>
-                    </plugin>                
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
- added automatic javadoc and source creation into profile
- removed staging plugin since its not needed

The issues this was failing to deploy is because the Maven Deploy Plugin did a first deployment and then the execution of the staging plugin did a second one. This failed since a release can only be deployed once.

I fixed this by removing the staging plugin since this is using a normal deployment. The other fix would be to set <extensions>true</extensions> in the staging plugin config. This would deactive the Maven Deploy plugin.

With the new setup you can run

mvn clean deploy -P release 

for snapshot and release versions and javadoc and sources will be deployed to Nexus in both cases.

And for running a release you only have to do 

mvn release:prepare release:perform

It will now automatically use the release profile due to the config in the release plugin. 