### PR TITLE
Working release process with mvn release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.javaee7.sample</groupId>
     <artifactId>javaee7-simple-sample</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.7</version>
     <packaging>war</packaging>
     <name>javaee7-simple-sample</name>
     <properties>
@@ -21,7 +21,7 @@
         <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
         <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
         <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
-        <tag>v1.5</tag>
+        <tag>v1.7</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.javaee7.sample</groupId>
     <artifactId>javaee7-simple-sample</artifactId>
-    <version>1.7</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>javaee7-simple-sample</name>
     <properties>
@@ -21,7 +21,7 @@
         <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
         <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
         <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
-        <tag>v1.7</tag>
+        <tag>v1.5</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
         </dependency>
     </dependencies>    
     <scm>
-        <connection>scm:git:https://github.com/javaee-samples/javaee7-simple-sample.git</connection>
-        <url>https://github.com/javaee-samples/javaee7-simple-sample.git</url>
-        <developerConnection>scm:git:https://github.com/javaee-samples/javaee7-simple-sample.git</developerConnection>
+        <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
+        <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
+        <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -42,22 +42,48 @@
         </snapshotRepository>
     </distributionManagement>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>2.3</version>
+                    <configuration>
+                        <failOnMissingWebXml>false</failOnMissingWebXml>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.1</version>
+                    <configuration>
+                        <tagNameFormat>v@{project.version}</tagNameFormat>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <releaseProfiles>release</releaseProfiles>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.1</version>
+                    <configuration>
+                        <show>private</show>
+                        <nohelp>true</nohelp>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
@@ -81,11 +107,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.1</version>
-                        <configuration>
-                            <show>private</show>
-                            <nohelp>true</nohelp>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -98,7 +119,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -107,16 +127,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.1</version>
-                        <configuration>
-                            <tagNameFormat>v@{project.version}</tagNameFormat>
-                            <autoVersionSubmodules>true</autoVersionSubmodules>
-                            <releaseProfiles>release</releaseProfiles>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.javaee7.sample</groupId>
     <artifactId>javaee7-simple-sample</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.6</version>
     <packaging>war</packaging>
     <name>javaee7-simple-sample</name>
     <properties>
@@ -21,7 +21,7 @@
         <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
         <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
         <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
-        <tag>v1.5</tag>
+        <tag>v1.6</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,9 @@
                     <configuration>
                         <tagNameFormat>v@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <!-- do not release profile from Maven super pom -->
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <!--  instead use our own one called release, see below -->
                         <releaseProfiles>release</releaseProfiles>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.javaee7.sample</groupId>
     <artifactId>javaee7-simple-sample</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.5</version>
     <packaging>war</packaging>
     <name>javaee7-simple-sample</name>
     <properties>
@@ -21,7 +21,7 @@
         <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
         <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
         <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.5</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
         </dependency>
     </dependencies>    
     <scm>
-        <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
-        <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
-        <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
+        <connection>scm:git:https://github.com/javaee-samples/javaee7-simple-sample.git</connection>
+        <url>https://github.com/javaee-samples/javaee7-simple-sample.git</url>
+        <developerConnection>scm:git:https://github.com/javaee-samples/javaee7-simple-sample.git</developerConnection>
         <tag>v1.5</tag>
     </scm>
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.javaee7.sample</groupId>
     <artifactId>javaee7-simple-sample</artifactId>
-    <version>1.6</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>javaee7-simple-sample</name>
     <properties>
@@ -21,7 +21,7 @@
         <connection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</connection>
         <url>https://github.com/mosabua/javaee7-simple-sample.git</url>
         <developerConnection>scm:git:https://github.com/mosabua/javaee7-simple-sample.git</developerConnection>
-        <tag>v1.6</tag>
+        <tag>v1.5</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.javaee7.sample</groupId>
     <artifactId>javaee7-simple-sample</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>javaee7-simple-sample</name>
     <properties>


### PR DESCRIPTION
I had to move the plugin setup to the pluginMgt so it kicks in. And also had to deactivate the release profile from the Maven super pom .. otherwise we end up with two sources jar generations (jar and jar-no-fork) and then two  upload attempts of these same files and therefore a failure. 

You could alternatively use the release profile from the super pom but that is less explicit and might be removed in the future.. so this is cleaner.